### PR TITLE
Add XHPROF_FLAGS_CPU for xhprof, cleanup for `ddev get`

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,8 @@
 name: ddev-buggregator
 
 project_files:
-- docker-compose.buggregator.yaml
+  - docker-compose.buggregator.yaml
+  - xhprof/xhprof_prepend.php
+
+# needed for xhprof/xhprof_prepend.php
+ddev_version_constraint: '>= v1.23.2'

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -4,7 +4,7 @@ setup() {
   export TESTDIR=~/tmp/test-buggregator
   mkdir -p $TESTDIR
   export PROJNAME=test-buggregator
-  export DDEV_NON_INTERACTIVE=true
+  export DDEV_NONINTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
@@ -13,8 +13,7 @@ setup() {
 
 health_checks() {
   # Do something useful here that verifies the add-on
-  # ddev exec "curl -s elasticsearch:9200" | grep "${PROJNAME}-elasticsearch"
-  ddev exec "curl -s https://localhost:443/"
+  ddev exec "curl -s http://buggregator:8000/"
 }
 
 teardown() {
@@ -27,17 +26,18 @@ teardown() {
 @test "install from directory" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get ${DIR}
+  echo "# ddev add-on get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get ${DIR}
   ddev restart
   health_checks
 }
 
+# bats test_tags=release
 @test "install from release" {
   set -eu -o pipefail
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  echo "# ddev get iljapolanskis/ddev-buggregator with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
-  ddev get iljapolanskis/ddev-buggregator
+  echo "# ddev add-on get iljapolanskis/ddev-buggregator with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
+  ddev add-on get iljapolanskis/ddev-buggregator
   ddev restart >/dev/null
   health_checks
 }

--- a/xhprof/xhprof_prepend.php
+++ b/xhprof/xhprof_prepend.php
@@ -1,0 +1,57 @@
+<?php
+
+// #ddev-generated
+
+// Bugreggator throws an error with only xhprof_enable(XHPROF_FLAGS_MEMORY) (DDEV default).
+// This file uses xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY) to make it work.
+// See https://github.com/buggregator/server/issues/230
+
+// If you want to take over and customize this file, remove the line above
+// And check this file in.
+
+// This file is used by `ddev xhprof on` and determines the behavior
+// of xhprof when it is enabled. It is mounted into the ddev-webserver container
+// as /usr/local/bin/xhprof/xhprof_prepend.php
+
+// It can be customized for particular sites or for particular CMS versions.
+// Some suggestions and examples are provided below.
+
+$uri = "none";
+if (!empty($_SERVER) && array_key_exists('REQUEST_URI', $_SERVER)) {
+  $uri = $_SERVER['REQUEST_URI'];
+}
+
+// Enable xhprof profiling if we're not on an xhprof page
+if (extension_loaded('xhprof') && strpos($uri, '/xhprof') === false) {
+  // If this is too much information, just use xhprof_enable(), which shows CPU only
+  xhprof_enable(XHPROF_FLAGS_CPU + XHPROF_FLAGS_MEMORY);
+  register_shutdown_function('xhprof_completion');
+}
+
+// Write to the xhprof_html output and latest on completion
+function xhprof_completion()
+{
+  $xhprof_link_dir = "/var/xhprof/xhprof_html/latest/";
+
+  $xhprof_data = xhprof_disable();
+  $appNamespace = "ddev";
+  include_once '/var/xhprof/xhprof_lib/utils/xhprof_lib.php';
+  include_once '/var/xhprof/xhprof_lib/utils/xhprof_runs.php';
+
+  $xhprof_runs = new XHProfRuns_Default();
+  $run_id = $xhprof_runs->save_run($xhprof_data, $appNamespace);
+
+  // Uncomment to append profile link to the page (and remove the ddev generated first line)
+  // append_profile_link($run_id, $appNamespace);
+}
+
+// If invoked, this will append a profile link to the output HTML
+// This works on some CMSs, like Drupal 7. It does not work on Drupal8/9
+// and can have unwanted side-effects on TYPO3
+function append_profile_link($run_id, $appNamespace)
+{
+  $base_link = (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/xhprof/";
+
+  $profiler_url = sprintf('%sindex.php?run=%s&amp;source=%s', $base_link, $run_id, $appNamespace);
+  echo '<div id="xhprof"><a href="' . $profiler_url . '" target="_blank">xhprof profiler output</a></div>';
+}


### PR DESCRIPTION
## The Issue

- https://github.com/buggregator/server/issues/230
- https://github.com/buggregator/server/issues/259
- https://github.com/ddev/ddev/pull/5721#issuecomment-2410823697

## How This PR Solves The Issue

Adds XHPROF_FLAGS_CPU flag.
Cleanup for `ddev get`

## Manual Testing Instructions

```
mkdir xhprof-test && cd xhprof-test
ddev config --auto
ddev add-on get https://github.com/iljapolanskis/ddev-buggregator/tarball/main
ddev composer require --dev spiral-packages/profiler
ddev restart
```

Using  https://docs.buggregator.dev/config/xhprof.html#vanilla-php

Create `index.php`:

```php
<?php

require_once __DIR__."/vendor/autoload.php";

use SpiralPackages\Profiler\Profiler;
use SpiralPackages\Profiler\DriverFactory;
use SpiralPackages\Profiler\Storage\WebStorage;
use Symfony\Component\HttpClient\NativeHttpClient;

$storage = new WebStorage(
    new NativeHttpClient(),
    'http://buggregator:8000/api/profiler/store',
);

$driver = DriverFactory::detect();

$profiler = new Profiler(
    storage: $storage,
    driver: $driver,
    appName: 'My super app',
    tags: [
        // global tags
        'env' => 'local',
    ]
);

$profiler->start(ignoredFunctions: []);

echo 'Hello World';

$profiler->end(tags: [
    // Tags for specific requests
]);
```

And:

```
ddev xhprof on
ddev launch
ddev launch :8000/#profiler
```

The data from xhprof should be here:

![image](https://github.com/user-attachments/assets/60cecf4c-77e9-4394-92a0-a7fafc59b206)

And click it:

![image](https://github.com/user-attachments/assets/a0dc9f88-a7fb-4897-b9db-a37e6d3f23f9)
